### PR TITLE
Added mid-training output

### DIFF
--- a/divisiondetector/datasets.py
+++ b/divisiondetector/datasets.py
@@ -24,6 +24,8 @@ class DivisionDataset(Dataset):
         return when querying.
 
         mode: Mode of the point rasterisation. Can be either 'ball' or 'peak'
+
+        ball_radius: Radius of rasterised ball.
         '''
 
         def __getlabels(label_path, div_path=None):

--- a/divisiondetector/monitoring.py
+++ b/divisiondetector/monitoring.py
@@ -1,0 +1,70 @@
+import os
+import zarr
+import numpy as np
+from pytorch_lightning import Callback
+
+from divisiondetector.utils.utils import BuildFromArgparse
+
+write_path = 'sample_training_output'
+
+class MonitorCallback(Callback, BuildFromArgparse):
+    def __init__(self, feedback_epoch=20, feedback_batch=0):
+        self.feedback_epoch = feedback_epoch
+        self.feedback_batch = feedback_batch
+        self.state = {'current_epoch': 0}
+
+    def on_validation_epoch_end(self, trainer, pl_module):
+        self.state['current_epoch'] += 1
+
+    def on_validation_batch_start(self, trainer, pl_module, batch, batch_idx, dataloader_idx) -> None:
+        if self.state['current_epoch'] == self.feedback_epoch and batch_idx == self.feedback_batch:
+            x, y = batch
+            y_hat = pl_module(x)
+
+            os.makedirs(write_path, exist_ok=True)
+            fn = os.path.join(write_path, f"epoch_{self.state['current_epoch']}_batch_{batch_idx}.zarr")
+
+            self.write_zarr(x, y, y_hat, fn)
+
+    def write_zarr(self, x, y, y_hat, fn):
+        zarr_store = zarr.open(fn, 'w')
+
+        b, c, t, d, h, w = x.shape
+        zarr_store.create_dataset(
+            "volumes",
+            data=x.cpu().detach().numpy(),
+            chunks=(b, c, t, d//4, h//8, w//8),
+            compression='lz4',
+            overwrite=True
+        )
+
+        y = y[:, np.newaxis, :, :, :, :]
+        b, c, t, d, h, w = y.shape
+        zarr_store.create_dataset(
+            "divisions",
+            data=y.cpu().detach().numpy(),
+            chunks=(b, c, t, d//4, h//8, w//8),
+            compression='lz4',
+            overwrite=True
+        )
+
+        b, c, t, d, h, w = y_hat.shape
+        zarr_store.create_dataset(
+            "predictions",
+            data=y_hat.cpu().detach().numpy(),
+            chunks=(b, c, t, d//4, h//8, w//8),
+            compression='lz4',
+            overwrite=True
+        )
+    
+    def on_load_checkpoint(self, trainer, pl_module, callback_state):
+        return self.state.update(callback_state)
+
+    def on_save_checkpoint(self, trainer, pl_module, checkpoint):
+        return self.state.copy()
+
+    @staticmethod
+    def add_argparse_args(parser):
+        parser.add_argument('--feedback_epoch', type=int, default=20)
+        parser.add_argument('--feedback_batch', type=int, default=0)
+        return parser

--- a/divisiondetector/train.py
+++ b/divisiondetector/train.py
@@ -2,6 +2,7 @@ from argparse import ArgumentParser
 from divisiondetector.datamodules import DivisionDataModule
 from divisiondetector.trainingmodules import DivisionDetectorTrainer
 from divisiondetector.utils.utils import SaveModelOnValidation
+from divisiondetector.monitoring import MonitorCallback
 # from divisiondetector.evaluation import DivisionPerformanceValidation
 
 import pytorch_lightning as pl
@@ -15,6 +16,7 @@ if __name__ == '__main__':
     parser = pl.Trainer.add_argparse_args(parser)
     parser = DivisionDataModule.add_argparse_args(parser)
     parser = DivisionDataModule.add_model_specific_args(parser)
+    parser = MonitorCallback.add_argparse_args(parser)
 
     args = parser.parse_args()
 
@@ -23,10 +25,12 @@ if __name__ == '__main__':
     # TODO: (when we have a working training module) Add a validation callback here
     # Ignore that for now :)
     # div_val = DivisionPerformanceValidation()
+    monitor_callback = MonitorCallback.from_argparse_args(args)
     model_saver = SaveModelOnValidation()
 
     #  init trainer
     trainer = pl.Trainer.from_argparse_args(args)
     trainer.callbacks.append(model_saver)
+    trainer.callbacks.append(monitor_callback)
     # trainer.callbacks.append(div_val)
     trainer.fit(model, datamodule)

--- a/tests/train_test.py
+++ b/tests/train_test.py
@@ -3,6 +3,7 @@
 from argparse import ArgumentParser
 from divisiondetector.datamodules import DivisionDataModule
 from divisiondetector.trainingmodules import DivisionDetectorTrainer
+from divisiondetector.monitoring import MonitorCallback
 
 import pytorch_lightning as pl
 
@@ -15,12 +16,15 @@ if __name__ == '__main__':
     parser = pl.Trainer.add_argparse_args(parser)
     parser = DivisionDataModule.add_argparse_args(parser)
     parser = DivisionDataModule.add_model_specific_args(parser)
+    parser = MonitorCallback.add_argparse_args(parser)
 
     args = parser.parse_args()
 
     model = DivisionDetectorTrainer.from_argparse_args(args)
     datamodule = DivisionDataModule.from_argparse_args(args)
+    monitor_callback = MonitorCallback.from_argparse_args(args)
 
     #  init trainer
     trainer = pl.Trainer.from_argparse_args(args)
+    trainer.callbacks.append(monitor_callback)
     trainer.fit(model, datamodule)


### PR DESCRIPTION
Writes zarr datasets for x, y and y_hat for a specified epoch and batch during training (for visualisation purposes).